### PR TITLE
Fix seat and spawn point missing `_get_supported_extensions`

### DIFF
--- a/addons/omi_extensions/misc/omi_seat.gd
+++ b/addons/omi_extensions/misc/omi_seat.gd
@@ -9,6 +9,10 @@ func _import_preflight(_state: GLTFState, extensions: PackedStringArray) -> Erro
 	return ERR_SKIP
 
 
+func _get_supported_extensions() -> PackedStringArray:
+	return PackedStringArray(["OMI_seat"])
+
+
 func _import_node(_state: GLTFState, _gltf_node: GLTFNode, json: Dictionary, node: Node) -> Error:
 	if not json.has("extensions"):
 		return OK

--- a/addons/omi_extensions/misc/omi_spawn_point.gd
+++ b/addons/omi_extensions/misc/omi_spawn_point.gd
@@ -9,6 +9,10 @@ func _import_preflight(_state: GLTFState, extensions: PackedStringArray) -> Erro
 	return ERR_SKIP
 
 
+func _get_supported_extensions() -> PackedStringArray:
+	return PackedStringArray(["OMI_spawn_point"])
+
+
 func _import_node(_state: GLTFState, _gltf_node: GLTFNode, json: Dictionary, node: Node) -> Error:
 	if not json.has("extensions"):
 		return OK


### PR DESCRIPTION
This method is necessary for the extension to tell the GLTF importer what extensions are supported so that it can perform a compatibility check when reading a document's `extensionsRequired`.